### PR TITLE
Added support for a certificate-based authentication method

### DIFF
--- a/microsoft-graph/connector.py
+++ b/microsoft-graph/connector.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2023 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/microsoft-graph/connector.py
+++ b/microsoft-graph/connector.py
@@ -5,9 +5,8 @@
   Copyright end """
 
 from connectors.core.connector import Connector, get_logger, ConnectorError
-from .operations import operations, _check_health, API_VERSION
-
-
+from .operations import operations, _check_health, API_VERSION, AUTH_BEHALF_OF_USER
+from connectors.core.utils import update_connnector_config
 logger = get_logger('microsoft_graph')
 
 
@@ -28,3 +27,18 @@ class MicrosoftGraph(Connector):
         config['connector_info'] = {"connector_name": self._info_json.get('name'),
                                     "connector_version": self._info_json.get('version')}
         return _check_health(config)
+
+    def on_update_config(self, old_config, new_config, active):
+        connector_info = {"connector_name": self._info_json.get('name'),
+                          "connector_version": self._info_json.get('version')}
+
+        if new_config.get('auth_type', '') == AUTH_BEHALF_OF_USER:
+            old_auth_code = old_config.get('code')
+            new_auth_code = new_config.get('code')
+            if old_auth_code != new_auth_code:
+                new_config.pop('accessToken', '')
+            else:
+                new_config['accessToken'] = old_config.get('accessToken')
+                new_config['expiresOn'] = old_config.get('expiresOn')
+            update_connnector_config(connector_info['connector_name'], connector_info['connector_version'], new_config,
+                                 new_config['config_id'])

--- a/microsoft-graph/constants.py
+++ b/microsoft-graph/constants.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2023 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/microsoft-graph/constants.py
+++ b/microsoft-graph/constants.py
@@ -41,10 +41,10 @@ API_VERSION = 'v1.0'
 AUTH_USING_APP = "Without a User - Application Permission"
 AUTH_BEHALF_OF_USER = "On behalf of User - Delegate Permission"
 REFRESH_TOKEN_FLAG = False
-CONFIG_SUPPORTS_TOKEN = True
 DEFAULT_REDIRECT_URL = 'https://localhost/myapp'
 AUTH_URL = 'https://login.microsoftonline.com'
 # grant types
 CLIENT_CREDENTIALS = 'client_credentials'
 AUTHORIZATION_CODE = 'authorization_code'
 REFRESH_TOKEN = 'refresh_token'
+CERTIFICATE_BASED_AUTH_TYPE = "Certificate Based Authentication"

--- a/microsoft-graph/info.json
+++ b/microsoft-graph/info.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-graph",
   "label": "Microsoft Graph API",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Microsoft Graph API is a powerful and unified programming interface provided by Microsoft that allows developers to access a wide range of data and services from Microsoft 365 and Azure Active Directory (Azure AD). It provides a single endpoint and a consistent set of RESTful web APIs, making it easier for developers to integrate and interact with Microsoft's cloud services and applications.",
   "publisher": "Fortinet",
   "cs_approved": true,
@@ -9,50 +9,10 @@
   "category": "Utilities",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/2.0.0/microsoft-graph-api/693/microsoft-graph-api-v2-0-0",
+  "help_online": "",
   "ingestion_supported": false,
   "configuration": {
     "fields": [
-      {
-        "title": "Server URL",
-        "required": true,
-        "editable": true,
-        "visible": true,
-        "type": "text",
-        "name": "resource",
-        "value": "https://graph.microsoft.com",
-        "description": "Specify the service-based URI to connect and perform automated operations."
-      },
-      {
-        "title": "Tenant ID",
-        "description": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
-        "tooltip": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
-        "required": true,
-        "editable": true,
-        "visible": true,
-        "type": "text",
-        "name": "tenant"
-      },
-      {
-        "title": "Client ID",
-        "description": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section.",
-        "required": true,
-        "editable": true,
-        "visible": true,
-        "type": "text",
-        "name": "client_id",
-        "tooltip": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section."
-      },
-      {
-        "title": "Client Secret",
-        "description": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API. For information on how to get the secret key, see https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp.",
-        "required": true,
-        "editable": true,
-        "visible": true,
-        "type": "password",
-        "name": "client_secret",
-        "tooltip": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API."
-      },
       {
         "title": "Get Access Token",
         "required": true,
@@ -61,14 +21,97 @@
         "type": "select",
         "options": [
           "Without a User - Application Permission",
-          "On behalf of User - Delegate Permission"
+          "On behalf of User - Delegate Permission",
+          "Certificate Based Authentication"
         ],
         "name": "auth_type",
         "value": "Without a User - Application Permission",
-        "description": "Select the method using which you will get authentication tokens used to access the security graph APIs. You can choose between On behalf of User - Delegate Permission or Without a User - Application Permission.",
+        "description": "Select the method using which you will get authentication tokens used to access the security graph APIs. You can choose between On behalf of User - Delegate Permission, Without a User - Application Permission or Certificate Based Authentication.",
         "tooltip": "Select the method using which you will get authentication tokens used to access the security graph APIs.",
         "onchange": {
+          "Without a User - Application Permission": [
+            {
+              "title": "Server URL",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "resource",
+              "value": "https://graph.microsoft.com",
+              "description": "Specify the service-based URI to connect and perform automated operations."
+            },
+            {
+              "title": "Tenant ID",
+              "description": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "tooltip": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "tenant"
+            },
+            {
+              "title": "Client ID",
+              "description": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "client_id",
+              "tooltip": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section."
+            },
+            {
+              "title": "Client Secret",
+              "description": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API. For information on how to get the secret key, see https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "password",
+              "name": "client_secret",
+              "tooltip": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API."
+            }
+          ],
           "On behalf of User - Delegate Permission": [
+            {
+              "title": "Server URL",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "resource",
+              "value": "https://graph.microsoft.com",
+              "description": "Specify the service-based URI to connect and perform automated operations."
+            },
+            {
+              "title": "Tenant ID",
+              "description": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "tooltip": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "tenant"
+            },
+            {
+              "title": "Client ID",
+              "description": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "client_id",
+              "tooltip": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section."
+            },
+            {
+              "title": "Client Secret",
+              "description": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API. For information on how to get the secret key, see https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "password",
+              "name": "client_secret",
+              "tooltip": "Specify the Unique Client Secret of the Azure Active Directory application that is used to create an authentication token required to access the API."
+            },
             {
               "title": "Authorization Code",
               "required": true,
@@ -89,6 +132,58 @@
               "name": "redirect_url",
               "placeholder": "e.g. https://localhost/myapp",
               "description": "The redirect_uri of your app, where authentication responses can be sent and received by your app. The redirect URL that you specify here must exactly match one of the redirect_uri's you have registered in your app registration portal."
+            }
+          ],
+          "Certificate Based Authentication": [
+            {
+              "title": "Server URL",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "resource",
+              "value": "https://graph.microsoft.com",
+              "description": "Specify the service-based URI to connect and perform automated operations."
+            },
+            {
+              "title": "Tenant ID",
+              "description": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "tooltip": "Specify the ID of the tenant assigned to you by the Azure application registration portal.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "tenant"
+            },
+            {
+              "title": "Client ID",
+              "description": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section.",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "client_id",
+              "tooltip": "Specify the Unique Application ID of the Azure Active Directory application to create an authentication token required to access the API. For information on getting authentication tokens, see the Getting Authentication Tokens section."
+            },
+            {
+              "title": "Certificate Thumbprint",
+              "type": "password",
+              "name": "thumbprint",
+              "description": "Provides a thumbprint, fingerprint, or hash, which is a unique identifier generated from a digital certificate using a cryptographic hash function.",
+               "tooltip": "Provides a thumbprint, fingerprint, or hash, which is a unique identifier generated from a digital certificate using a cryptographic hash function.",
+              "required": true,
+              "editable": true,
+              "visible": true
+            },
+            {
+              "title": "Certificate File",
+              "name": "private_key",
+              "type": "file",
+              "tooltip": "Upload a certificate (public key) with one of the following file types: .cer, .pem, .crt",
+              "description": "Upload a certificate (public key) with one of the following file types: .cer, .pem, .crt",
+              "editable": true,
+              "visible": true,
+              "required": true
             }
           ]
         }

--- a/microsoft-graph/microsoft_api_auth.py
+++ b/microsoft-graph/microsoft_api_auth.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2023 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/microsoft-graph/operations.py
+++ b/microsoft-graph/operations.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2023 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/microsoft-graph/operations.py
+++ b/microsoft-graph/operations.py
@@ -3,18 +3,14 @@
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
-
-from .utils import _list
 from queue import Queue
 from threading import Thread
 import threading
 import requests
 from .microsoft_api_auth import *
-import logging
-
-
+from .utils import _list
+from connectors.core.connector import get_logger, ConnectorError
 logger = get_logger('microsoft_graph')
-# logger.setLevel(logging.DEBUG) # Uncomment to enable local debug
 
 
 class SetupSession(object):

--- a/microsoft-graph/playbooks/playbooks.json
+++ b/microsoft-graph/playbooks/playbooks.json
@@ -4,7 +4,7 @@
     {
       "uuid": "585a99d1-de55-42f0-9b80-4c7d63a5463d",
       "@type": "WorkflowCollection",
-      "name": "Sample - Microsoft Graph API - 2.0.0",
+      "name": "Sample - Microsoft Graph API - 2.1.0",
       "description": "Microsoft Graph API is a powerful and unified programming interface provided by Microsoft that allows developers to access a wide range of data and services from Microsoft 365 and Azure Active Directory (Azure AD). It provides a single endpoint and a consistent set of RESTful web APIs, making it easier for developers to integrate and interact with Microsoft's cloud services and applications.",
       "visible": true,
       "image": null,
@@ -68,12 +68,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_risky_users_list",
                 "operationTitle": "Get Risky Users List",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -148,12 +147,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_risky_user_details",
                 "operationTitle": "Get Risky User Details",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -228,12 +226,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_all_security_alerts",
                 "operationTitle": "Get All Security Alerts",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -308,12 +305,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_security_alert",
                 "operationTitle": "Get Security Alert",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -388,12 +384,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "update_security_alert",
                 "operationTitle": "Update Security Alert",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -468,12 +463,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_groups",
                 "operationTitle": "Get Groups",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -548,12 +542,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_group_users",
                 "operationTitle": "Get Users Within A Group",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -628,12 +621,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "search_message",
                 "operationTitle": "Search Message in Users Mailbox",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -708,12 +700,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "del_message",
                 "operationTitle": "Delete Message",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -790,12 +781,11 @@
                 "params": {
                   "user_list": []
                 },
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "del_message_bulk",
                 "operationTitle": "Delete Message Bulk",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -870,12 +860,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "revoke_user_sessions",
                 "operationTitle": "Revoke User Session",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -952,12 +941,11 @@
                 "params": {
                   "count": false
                 },
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "get_all_named_locations",
                 "operationTitle": "Get All Named Locations",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -1032,12 +1020,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "block_new_ips",
                 "operationTitle": "Block New IP Ranges",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -1112,12 +1099,11 @@
                 "name": "Microsoft Graph API",
                 "config": "''",
                 "params": [],
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "unblock_new_ips",
                 "operationTitle": "Unblock IP Ranges",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",
@@ -1194,12 +1180,11 @@
                 "params": {
                   "is_trusted": false
                 },
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "connector": "microsoft-graph",
                 "operation": "create_ip_range_location",
                 "operationTitle": "Create IP Named Location",
                 "step_variables": {
-                  "output_data": "{{vars.result}}"
                 }
               },
               "left": "188",

--- a/microsoft-graph/release_notes.md
+++ b/microsoft-graph/release_notes.md
@@ -1,3 +1,3 @@
 #### What's Improved
 - Added support for a certificate-based authentication method. 
-  - Added `Certificate Based Autentication` new options qfor the `Get Access Token` configuration parameter 
+  - Added `Certificate Based Autentication` new options for the `Get Access Token` configuration parameter 

--- a/microsoft-graph/release_notes.md
+++ b/microsoft-graph/release_notes.md
@@ -1,5 +1,3 @@
 #### What's Improved
-- Added support for the Delegate access token type. 
-- Removed configuration parameter `API Version`.
-- Added `Unblock IP Ranges` action
-- Added `Create IP Named Location` action
+- Added support for a certificate-based authentication method. 
+  - Added `Certificate Based Autentication` new options qfor the `Get Access Token` configuration parameter 

--- a/microsoft-graph/utils.py
+++ b/microsoft-graph/utils.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2023 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
@@ -15,7 +15,7 @@ def _list(user_list):
     elif isinstance(user_list, tuple):
         user_list = list(user_list)
     elif isinstance(user_list, list):
-        user_list
+        return user_list
     else:
         logger.error('Incorrect Input')
         raise ConnectorError('Incorrect Input')


### PR DESCRIPTION
Following changes added in this PR

1. Added support for a certificate-based authentication method (NFR/Mantis ID:0983258)
2. Fixed auth `code was already redeemed issue` on update connector config for `On behalf of User - Delegate Permission` type.
3. Updated copyrights contents


UTC:
----
Verified connector action and check health for all supportive Authentication mechanisms `On behalf of User - Delegate Permission`, `Without a User - Application Permission`, and `Certificate Based Authentication`
