### PR TITLE
Bug Fixes

### DIFF
--- a/microsoft-graph/info.json
+++ b/microsoft-graph/info.json
@@ -179,8 +179,8 @@
               "title": "Certificate File",
               "name": "private_key",
               "type": "file",
-              "tooltip": "Upload a certificate (public key) with one of the following file types: .cer, .pem, .crt",
-              "description": "Upload a certificate (public key) with one of the following file types: .cer, .pem, .crt",
+              "tooltip": "Upload a certificate (private key) with one of the following file types: .cer, .pem, .crt",
+              "description": "Upload a certificate (private key) with one of the following file types: .cer, .pem, .crt",
               "editable": true,
               "visible": true,
               "required": true

--- a/microsoft-graph/microsoft_api_auth.py
+++ b/microsoft-graph/microsoft_api_auth.py
@@ -4,7 +4,7 @@ MIT License
 Copyright (c) 2024 Fortinet Inc
 Copyright end
 """
-import msal
+import msal, base64
 from urllib.parse import urljoin
 from requests import request
 from time import time, ctime
@@ -49,8 +49,12 @@ class MicrosoftAuth:
             if isinstance(config.get('private_key', {}), dict) and config.get('private_key', {}).get('@type') == "File":
                 private_key_file_iri = config.get('private_key', {}).get('@id')
                 logger.debug('certificate file iri: {}'.format(private_key_file_iri))
-                self.private_key = make_request(private_key_file_iri, 'GET')
-
+                self.private_key = self.private_key = make_request(private_key_file_iri, 'GET')
+                try:
+                    # agent machine make_rest call to retrieve file data in encoded format
+                    self.private_key = base64.b64decode(self.private_key, validate=True)
+                except Exception as e:
+                    pass
 
     def convert_ts_epoch(self, ts):
         datetime_object = datetime.strptime(ctime(ts), "%a %b %d %H:%M:%S %Y")


### PR DESCRIPTION
Mantis Summary
-----
Mantis ID: 1003752 
Issue: Configuration fails on the agent due to the certificate file content being in a encoded format

Mantis ID: 1003753
Updated tooltip for `Certificate File` parameters
